### PR TITLE
 LeetCode 讀書會第 37 次聚會 2022/01/25

### DIFF
--- a/紀錄/37 2022-01-25 Binary tree final.md
+++ b/紀錄/37 2022-01-25 Binary tree final.md
@@ -1,0 +1,22 @@
+# LeetCode 讀書會第 37 次聚會 2022/01/25
+
+## leetcode 讀書會通知
+
+1. 項目: 第 37 次聚會
+2. 目的: 線上一起寫題目, 由有想法的人帶領, 先解題, 再看該題有趣的解法
+3. 時間: 01/25 (二) 20:00 ~ 21:00
+4. 地點: google meet 線上 (前 10 分鐘預備鏈接)
+5. 解題項目:  [Binary Tree](https://leetcode.com/explore/learn/card/data-structure-tree/)
+6. 共筆: GitHub https://github.com/programmingbookclub/Leetcode-club
+7. 備註: 
+
+這次針對 297 處理 deserialize，主持人不會做任何的提示。會 recap binary tree 與選下一回合的主題。
+
+
+* 	HARD	297	Serialize and Deserialize Binary Tree	https://leetcode.com/problems/serialize-and-deserialize-binary-tree
+
+--- 
+Notes:
+
+Yu solution:
+https://leetcode.com/problems/serialize-and-deserialize-binary-tree/discuss/1713298/Swift-deserialize-with-one-pass


### PR DESCRIPTION


## leetcode 讀書會通知

1. 項目: 第 37 次聚會
2. 目的: 線上一起寫題目, 由有想法的人帶領, 先解題, 再看該題有趣的解法
3. 時間: 01/25 (二) 20:00 ~ 21:00
4. 地點: google meet 線上 (前 10 分鐘預備鏈接)
5. 解題項目:  [Binary Tree](https://leetcode.com/explore/learn/card/data-structure-tree/)
6. 共筆: GitHub https://github.com/programmingbookclub/Leetcode-club
7. 備註: 

這次針對 297 處理 deserialize，主持人不會做任何的提示。會 recap binary tree 與選下一回合的主題。


* 	HARD	297	Serialize and Deserialize Binary Tree	https://leetcode.com/problems/serialize-and-deserialize-binary-tree